### PR TITLE
refactor: unify and fix send/Request helpersRename and consolidate send/Request helper functions and fix callingsites to standard behavior visibility.

### DIFF
--- a/go/Client/connection.go
+++ b/go/Client/connection.go
@@ -293,6 +293,7 @@ func (r *Connection) SendResponse(req *core.Request) bool {
 		}
 		r.once_done = true
 	}
+	req.Server()
 	r.requestQueue <- req
 
 	return true

--- a/go/Server/Client.go
+++ b/go/Server/Client.go
@@ -117,7 +117,7 @@ func ClientHandleNew(conn net.Conn) {
 	if err != nil {
 		panic(err.Error())
 	}
-	Send(conn, isr)
+	send(conn, isr)
 
 	var opcode []byte = make([]byte, 4)
 
@@ -131,7 +131,7 @@ func ClientHandleNew(conn net.Conn) {
 		opcode[2] >= core.SNF_OPCODE_BASE_CMD_CONNECT &&
 		opcode[2] <= core.SNF_OPCODE_BASE_CMD_DISCONNECT) {
 		//Invalid Opcode
-		if err := Send(conn,
+		if err := send(conn,
 			[]byte{
 				0x00,                             /*OPC Cat*/
 				0x00,                             /*OPC SubCat*/
@@ -174,7 +174,7 @@ func ClientHandleNew(conn net.Conn) {
 				Data:      data,
 			}
 		default:
-			Send(conn,
+			send(conn,
 				[]byte{
 					0x00,                             /*OPC Cat*/
 					0x00,                             /*OPC SubCat*/
@@ -195,11 +195,11 @@ func ClientHandleNew(conn net.Conn) {
 				0x00, 0x00, 0x00, 0x10, /*S Args*/
 			}
 			snd = append(snd, client.UUID[:]...)
-			Send(conn, snd)
+			send(conn, snd)
 		}
 	case core.SNF_OPCODE_BASE_CMD_RECONNECT:
 		// Temporary
-		Send(conn,
+		send(conn,
 			[]byte{
 				0x00,                             /*OPC Cat*/
 				0x00,                             /*OPC SubCat*/
@@ -212,7 +212,7 @@ func ClientHandleNew(conn net.Conn) {
 	case core.SNF_OPCODE_BASE_CMD_DISCONNECT:
 	default:
 		//Temporary Different just to know they are different thatn reconnect
-		Send(conn,
+		send(conn,
 			[]byte{
 				0x00,                             /*OPC Cat*/
 				0x00,                             /*OPC SubCat*/
@@ -242,7 +242,7 @@ func ClientHandle(client *Client) {
 			switch {
 			case errors.Is(err, core.SNFErrorOpcodeInvalid{}):
 				//Error handling comes later.
-				RequestSend(client,
+				Send(client,
 					core.RequestGen().
 						RespondsTo(req).
 						SetOpcode(
@@ -254,7 +254,7 @@ func ClientHandle(client *Client) {
 				return
 			default:
 				// Respond with the value of the error/ Debug only
-				RequestSend(client,
+				Send(client,
 					core.RequestGen().
 						RespondsTo(req).
 						SetOpcode(

--- a/go/Server/Network.go
+++ b/go/Server/Network.go
@@ -98,6 +98,7 @@ func Start() error {
 
 	listener, err := getSocket()
 	if err != nil {
+		println("_+_+_+_+_+_+ ")
 		snfWaitStart <- err
 		return err
 	}
@@ -108,7 +109,12 @@ func Start() error {
 
 		if err == nil {
 			go ClientHandleNew(conn)
+		} else {
+
+			println("-=-=-=-=-=-=-=  ")
+
 		}
+
 	}
 }
 
@@ -121,8 +127,8 @@ func WaitStart() error {
 	return <-snfWaitStart
 }
 
-// Send a message over the network connection.
-func Send(conn net.Conn, data []byte) error {
+// send a message over the network connection.
+func send(conn net.Conn, data []byte) error {
 	if _, err := conn.Write(data); err != nil {
 		return err
 	}

--- a/go/Server/requests.go
+++ b/go/Server/requests.go
@@ -167,16 +167,25 @@ func RequestSend(client *Client, Request *core.Request) error {
 	}
 	return err
 }
+
+// Allows to send a client response
 func ResponseSend(client *Client, Request *core.Request) error {
 	return requestSend(client, Request, true)
 
 }
 func requestSend(client *Client, Request *core.Request, Response bool) error {
-	var content []byte
 
-	if !Response {
+	if Response {
+		Request.Client()
+	} else {
 		Request.Server()
 	}
+	return Send(client, Request)
+}
+
+// Allows to send a non specefied request
+func Send(client *Client, Request *core.Request) error {
+	var content []byte
 
 	content = append(content, Request.ToBytes()...)
 


### PR DESCRIPTION
- Change exported Send(conn, data) to unexported send, data) and update all Server.Client.go call sites to use send. This reduces accidental external use and internal.
- Introduce Send(client, *core.Request) simplify requestSend to delegate bytes generation and sending. Add ResponseSend as thin for-specific sends.
- Ensure Request.Server()/Request.Client() is invoked appropriately when requests/responses (requests.go, connection.go).
- Minor network startup logging and small control-flow cleanup in Network.go to surface errorsThese changes fix API, centralize sending,
and make request direction handling explicit to avoid incorrectrequest encoding.